### PR TITLE
Fixing broken link for time stamping validation guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Alternatively you can copy the SoftwareTimeStamping Folder into C:\Program Files
 
 #### Test
 
-Please try out our validation guide!
-https://github.com/Microsoft/W32Time/blob/master/Timestamping/docs/Validation%20Guide%20-%20RS5%20-%20Software%20Timestamping.docx
+Please try out our [validation guide](https://github.com/aprotyas/W32Time/blob/master/Timestamping/docs/Validation%20Guide%20-%20Software%20Timestamping.docx)!
 
 ## Precision Time Protocol
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Alternatively you can copy the SoftwareTimeStamping Folder into C:\Program Files
 
 #### Test
 
-Please try out our [validation guide](https://github.com/aprotyas/W32Time/blob/master/Timestamping/docs/Validation%20Guide%20-%20Software%20Timestamping.docx)!
+Please try out our [validation guide](https://github.com/microsoft/W32Time/blob/master/Timestamping/docs/Validation%20Guide%20-%20Software%20Timestamping.docx)!
 
 ## Precision Time Protocol
 


### PR DESCRIPTION
Minor change to the link pointing to the correct document for the validation guide of the software time-stamping powershell module.